### PR TITLE
WIP: RDAODTD-2327: Tag-based mask

### DIFF
--- a/src/main/java/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/java/META-INF/additional-spring-configuration-metadata.json
@@ -50,6 +50,11 @@
     "description": "A description for 'datahub.admin.api.configurations.images.path'"
   },
   {
+    "name": "datahub.admin.api.configurations.mask.tag",
+    "type": "java.lang.String",
+    "description": "A description for 'datahub.admin.api.configurations.mask.tag'"
+  },
+  {
     "name": "datahub.admin.api.es.repos.limit",
     "type": "java.lang.String",
     "description": "A description for 'datahub.admin.api.es.repos.limit'"

--- a/src/main/java/gov/dot/its/datahub/adminapi/business/DataAssetsService.java
+++ b/src/main/java/gov/dot/its/datahub/adminapi/business/DataAssetsService.java
@@ -9,7 +9,7 @@ import gov.dot.its.datahub.adminapi.model.DataAsset;
 
 public interface DataAssetsService {
 
-	ApiResponse<List<DataAsset>> dataAssets(HttpServletRequest request);
+	ApiResponse<List<DataAsset>> dataAssets(HttpServletRequest request, boolean includeMasked);
 
 	ApiResponse<DataAsset> dataAsset(HttpServletRequest request, String id);
 

--- a/src/main/java/gov/dot/its/datahub/adminapi/business/DataAssetsServiceImpl.java
+++ b/src/main/java/gov/dot/its/datahub/adminapi/business/DataAssetsServiceImpl.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import static java.lang.System.out;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -11,6 +12,7 @@ import org.elasticsearch.ElasticsearchStatusException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
@@ -26,6 +28,9 @@ public class DataAssetsServiceImpl implements DataAssetsService {
 
 	private static final Logger logger = LoggerFactory.getLogger(ConfigurationServiceImpl.class);
 	private static final String MESSAGE_TEMPLATE = "{} : {} ";
+	
+	@Value("${datahub.admin.api.configurations.mask.tag}")
+	private String maskTag;
 
 	@Autowired
 	private DataAssetsDao dataAssetsDao;
@@ -44,7 +49,7 @@ public class DataAssetsServiceImpl implements DataAssetsService {
 		try {
 			List<DataAsset> dataAssets = dataAssetsDao.getDataAssets();
 			if (!includeMasked) {
-				dataAssets = dataAssets.stream().filter(d -> !d.isHidden()).collect(Collectors.toList());
+				dataAssets = dataAssets.stream().filter(d -> !d.getTags().contains(this.maskTag)).collect(Collectors.toList());
 			}
 
 			if (!dataAssets.isEmpty()) {

--- a/src/main/java/gov/dot/its/datahub/adminapi/business/DataAssetsServiceImpl.java
+++ b/src/main/java/gov/dot/its/datahub/adminapi/business/DataAssetsServiceImpl.java
@@ -3,6 +3,7 @@ package gov.dot.its.datahub.adminapi.business;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -33,7 +34,7 @@ public class DataAssetsServiceImpl implements DataAssetsService {
 	private ApiUtils apiUtils;
 
 	@Override
-	public ApiResponse<List<DataAsset>> dataAssets(HttpServletRequest request) {
+	public ApiResponse<List<DataAsset>> dataAssets(HttpServletRequest request, boolean includeMasked) {
 		logger.info("Request: Data Assets");
 		final String RESPONSE_MSG = "Response: GET Data Assets. ";
 
@@ -41,8 +42,10 @@ public class DataAssetsServiceImpl implements DataAssetsService {
 		List<ApiError> errors = new ArrayList<>();
 
 		try {
-
 			List<DataAsset> dataAssets = dataAssetsDao.getDataAssets();
+			if (!includeMasked) {
+				dataAssets = dataAssets.stream().filter(d -> !d.isHidden()).collect(Collectors.toList());
+			}
 
 			if (!dataAssets.isEmpty()) {
 				apiResponse.setResponse(HttpStatus.OK, dataAssets, null, null, request);

--- a/src/main/java/gov/dot/its/datahub/adminapi/business/DataAssetsServiceImpl.java
+++ b/src/main/java/gov/dot/its/datahub/adminapi/business/DataAssetsServiceImpl.java
@@ -48,8 +48,10 @@ public class DataAssetsServiceImpl implements DataAssetsService {
 
 		try {
 			List<DataAsset> dataAssets = dataAssetsDao.getDataAssets();
+			out.println("includeMasked");
+			out.println(includeMasked);
 			if (!includeMasked) {
-				dataAssets = dataAssets.stream().filter(d -> !d.getTags().contains(this.maskTag)).collect(Collectors.toList());
+				dataAssets = dataAssets.stream().filter(d -> !d.getTags().contains("its-datahub-hide")).collect(Collectors.toList());
 			}
 
 			if (!dataAssets.isEmpty()) {

--- a/src/main/java/gov/dot/its/datahub/adminapi/controller/DataAssetsController.java
+++ b/src/main/java/gov/dot/its/datahub/adminapi/controller/DataAssetsController.java
@@ -31,7 +31,7 @@ public class DataAssetsController {
 		HttpServletRequest request, 
 		@RequestParam(value="includeMasked", required=false, defaultValue="false") String includeMaskedString) {
 
-		boolean includeMasked = includeMaskedString == "false" ? false : true;
+		boolean includeMasked = Boolean.parseBoolean(includeMaskedString);
 		ApiResponse<List<DataAsset>> apiResponse = dataAssetsService.dataAssets(request, includeMasked);
 
 		return new ResponseEntity<>(apiResponse, HttpStatus.OK);
@@ -53,3 +53,4 @@ public class DataAssetsController {
 		return new ResponseEntity<>(apiResponse, HttpStatus.OK);
 	}
 }
+

--- a/src/main/java/gov/dot/its/datahub/adminapi/controller/DataAssetsController.java
+++ b/src/main/java/gov/dot/its/datahub/adminapi/controller/DataAssetsController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import gov.dot.its.datahub.adminapi.business.DataAssetsService;
@@ -26,9 +27,12 @@ public class DataAssetsController {
 	private DataAssetsService dataAssetsService;
 
 	@GetMapping(value="/v1/dataassets", headers="Accept=application/json", produces="application/json")
-	public ResponseEntity<ApiResponse<List<DataAsset>>> dataassets(HttpServletRequest request) {
+	public ResponseEntity<ApiResponse<List<DataAsset>>> dataassets(
+		HttpServletRequest request, 
+		@RequestParam(value="includeMasked", required=false, defaultValue="false") String includeMaskedString) {
 
-		ApiResponse<List<DataAsset>> apiResponse = dataAssetsService.dataAssets(request);
+		boolean includeMasked = includeMaskedString == "false" ? false : true;
+		ApiResponse<List<DataAsset>> apiResponse = dataAssetsService.dataAssets(request, includeMasked);
 
 		return new ResponseEntity<>(apiResponse, HttpStatus.OK);
 	}

--- a/src/main/java/gov/dot/its/datahub/adminapi/model/DataAsset.java
+++ b/src/main/java/gov/dot/its/datahub/adminapi/model/DataAsset.java
@@ -147,7 +147,7 @@ public class DataAsset {
 	}
 	
 	public boolean isHidden() {
-		return this.tags.contains(this.maskTag);
+		return this.getTags().contains(this.maskTag);
 	}
 
 }

--- a/src/main/java/gov/dot/its/datahub/adminapi/model/DataAsset.java
+++ b/src/main/java/gov/dot/its/datahub/adminapi/model/DataAsset.java
@@ -6,6 +6,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.beans.factory.annotation.Value;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -26,6 +28,9 @@ public class DataAsset {
 	private Metrics metrics;
 	private List<String> dhProjects;
 	private List<String> dhDataTypes;
+	
+	@Value("${datahub.admin.api.configurations.mask.tag}")
+	private String maskTag;
 
 	public DataAsset() {
 		this.tags = new ArrayList<>();
@@ -139,6 +144,10 @@ public class DataAsset {
 
 	public void setDhDataTypes(List<String> dhDataTypes) {
 		this.dhDataTypes = dhDataTypes;
+	}
+	
+	public boolean isHidden() {
+		return this.tags.contains(this.maskTag);
 	}
 
 }

--- a/src/main/java/gov/dot/its/datahub/adminapi/model/DataAsset.java
+++ b/src/main/java/gov/dot/its/datahub/adminapi/model/DataAsset.java
@@ -6,8 +6,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.springframework.beans.factory.annotation.Value;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -28,9 +26,6 @@ public class DataAsset {
 	private Metrics metrics;
 	private List<String> dhProjects;
 	private List<String> dhDataTypes;
-	
-	@Value("${datahub.admin.api.configurations.mask.tag}")
-	private String maskTag;
 
 	public DataAsset() {
 		this.tags = new ArrayList<>();
@@ -144,10 +139,6 @@ public class DataAsset {
 
 	public void setDhDataTypes(List<String> dhDataTypes) {
 		this.dhDataTypes = dhDataTypes;
-	}
-	
-	public boolean isHidden() {
-		return this.getTags().contains(this.maskTag);
 	}
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,3 +18,4 @@ datahub.admin.api.configurations.index=configurations
 datahub.admin.api.configurations.default=datahub-default-configuration
 datahub.admin.api.configurations.images.list=
 datahub.admin.api.configurations.images.path=
+datahub.admin.api.configurations.mask.tag=its-datahub-hide

--- a/src/test/java/gov/dot/its/datahub/adminapi/controller/ConfigurationControllerTest.java
+++ b/src/test/java/gov/dot/its/datahub/adminapi/controller/ConfigurationControllerTest.java
@@ -116,7 +116,7 @@ public class ConfigurationControllerTest {
 
 		when(configurationService.configurations(any(HttpServletRequest.class))).thenReturn(apiResponse);
 		ResultActions resultActions = this.testUtils.prepareResultActions(this.mockMvc, request.getMethod(),
-				"%s/v1/configurations", "api/v1/configurations/data", "");
+				"%s/v1/configurations", "api/v1/configurations/data", "", null);
 
 		MvcResult result = resultActions.andReturn();
 		String objString = result.getResponse().getContentAsString();
@@ -143,7 +143,7 @@ public class ConfigurationControllerTest {
 
 		when(configurationService.projects(any(HttpServletRequest.class))).thenReturn(apiResponse);
 		ResultActions resultActions = this.testUtils.prepareResultActions(this.mockMvc, request.getMethod(),
-				URL_PROJECTS_TEMPLATE, "api/v1/configurations/projects/get", null);
+				URL_PROJECTS_TEMPLATE, "api/v1/configurations/projects/get", null, null);
 
 		MvcResult result = resultActions.andReturn();
 		String objString = result.getResponse().getContentAsString();
@@ -170,7 +170,7 @@ public class ConfigurationControllerTest {
 
 		when(configurationService.project(any(HttpServletRequest.class), any(String.class))).thenReturn(apiResponse);
 		ResultActions resultActions = this.testUtils.prepareResultActions(this.mockMvc, request.getMethod(),
-				URL_PROJECTS_TEMPLATE + "/" + project.getId(), "api/v1/configurations/projects/get-id", null);
+				URL_PROJECTS_TEMPLATE + "/" + project.getId(), "api/v1/configurations/projects/get-id", null, null);
 
 		MvcResult result = resultActions.andReturn();
 		String objString = result.getResponse().getContentAsString();
@@ -199,7 +199,7 @@ public class ConfigurationControllerTest {
 
 		String projectStr = objectMapper.writeValueAsString(project);
 		ResultActions resultActions = this.testUtils.prepareResultActions(this.mockMvc, request.getMethod(),
-				URL_PROJECTS_TEMPLATE, "api/v1/configurations/projects/post", projectStr);
+				URL_PROJECTS_TEMPLATE, "api/v1/configurations/projects/post", projectStr, null);
 
 		MvcResult result = resultActions.andReturn();
 		String objString = result.getResponse().getContentAsString();
@@ -228,7 +228,7 @@ public class ConfigurationControllerTest {
 
 		String projectStr = objectMapper.writeValueAsString(project);
 		ResultActions resultActions = this.testUtils.prepareResultActions(this.mockMvc, request.getMethod(),
-				URL_PROJECTS_TEMPLATE, "api/v1/configurations/projects/put", projectStr);
+				URL_PROJECTS_TEMPLATE, "api/v1/configurations/projects/put", projectStr, null);
 
 		MvcResult result = resultActions.andReturn();
 		String objString = result.getResponse().getContentAsString();
@@ -255,7 +255,7 @@ public class ConfigurationControllerTest {
 		.thenReturn(apiResponse);
 
 		ResultActions resultActions = this.testUtils.prepareResultActions(this.mockMvc, request.getMethod(),
-				URL_PROJECTS_TEMPLATE + "/" + project.getId(), "api/v1/configurations/projects/delete", null);
+				URL_PROJECTS_TEMPLATE + "/" + project.getId(), "api/v1/configurations/projects/delete", null, null);
 
 		MvcResult result = resultActions.andReturn();
 		String objString = result.getResponse().getContentAsString();
@@ -282,7 +282,7 @@ public class ConfigurationControllerTest {
 		when(configurationService.projectImages(any(HttpServletRequest.class))).thenReturn(apiResponse);
 
 		ResultActions resultActions = this.testUtils.prepareResultActions(this.mockMvc, request.getMethod(),
-				"%s/v1/images/projects", "api/v1/configurations/projects/images", null);
+				"%s/v1/images/projects", "api/v1/configurations/projects/images", null, null);
 
 		MvcResult result = resultActions.andReturn();
 		String objString = result.getResponse().getContentAsString();
@@ -309,7 +309,7 @@ public class ConfigurationControllerTest {
 
 		when(configurationService.dataTypes(any(HttpServletRequest.class))).thenReturn(apiResponse);
 		ResultActions resultActions = this.testUtils.prepareResultActions(this.mockMvc, request.getMethod(),
-				URL_DATATYPES_TEMPLATE, "api/v1/configurations/datatypes/get", null);
+				URL_DATATYPES_TEMPLATE, "api/v1/configurations/datatypes/get", null, null);
 
 		MvcResult result = resultActions.andReturn();
 		String objString = result.getResponse().getContentAsString();
@@ -335,7 +335,7 @@ public class ConfigurationControllerTest {
 
 		when(configurationService.dataType(any(HttpServletRequest.class), any(String.class))).thenReturn(apiResponse);
 		ResultActions resultActions = this.testUtils.prepareResultActions(this.mockMvc, request.getMethod(),
-				URL_DATATYPES_TEMPLATE + "/" + dataType.getId(), "api/v1/configurations/datatypes/get-id", null);
+				URL_DATATYPES_TEMPLATE + "/" + dataType.getId(), "api/v1/configurations/datatypes/get-id", null, null);
 
 		MvcResult result = resultActions.andReturn();
 		String objString = result.getResponse().getContentAsString();
@@ -363,7 +363,7 @@ public class ConfigurationControllerTest {
 
 		String dataTypeStr = objectMapper.writeValueAsString(dataType);
 		ResultActions resultActions = this.testUtils.prepareResultActions(this.mockMvc, request.getMethod(),
-				URL_DATATYPES_TEMPLATE, "api/v1/configurations/datatypes/post", dataTypeStr);
+				URL_DATATYPES_TEMPLATE, "api/v1/configurations/datatypes/post", dataTypeStr, null);
 
 		MvcResult result = resultActions.andReturn();
 		String objString = result.getResponse().getContentAsString();
@@ -391,7 +391,7 @@ public class ConfigurationControllerTest {
 
 		String dataTypeStr = objectMapper.writeValueAsString(dataType);
 		ResultActions resultActions = this.testUtils.prepareResultActions(this.mockMvc, request.getMethod(),
-				URL_DATATYPES_TEMPLATE, "api/v1/configurations/datatypes/put", dataTypeStr);
+				URL_DATATYPES_TEMPLATE, "api/v1/configurations/datatypes/put", dataTypeStr, null);
 
 		MvcResult result = resultActions.andReturn();
 		String objString = result.getResponse().getContentAsString();
@@ -418,7 +418,7 @@ public class ConfigurationControllerTest {
 		.thenReturn(apiResponse);
 
 		ResultActions resultActions = this.testUtils.prepareResultActions(this.mockMvc, request.getMethod(),
-		URL_DATATYPES_TEMPLATE + "/" + dataType.getId(), "api/v1/configurations/datatypes/delete", null);
+		URL_DATATYPES_TEMPLATE + "/" + dataType.getId(), "api/v1/configurations/datatypes/delete", null, null);
 
 		MvcResult result = resultActions.andReturn();
 		String objString = result.getResponse().getContentAsString();
@@ -444,7 +444,7 @@ public class ConfigurationControllerTest {
 		when(configurationService.engagementpopups(any(HttpServletRequest.class))).thenReturn(apiResponse);
 		
 		ResultActions resultActions = this.testUtils.prepareResultActions(this.mockMvc, request.getMethod(),
-				URL_ENGAGEMENTPOPUP_TEMPLATE, "api/v1/configurations/engagementpopups/get", null);
+				URL_ENGAGEMENTPOPUP_TEMPLATE, "api/v1/configurations/engagementpopups/get", null, null);
 
 		MvcResult result = resultActions.andReturn();
 		String objString = result.getResponse().getContentAsString();
@@ -472,7 +472,7 @@ public class ConfigurationControllerTest {
 
 		String engagementPopupStr = objectMapper.writeValueAsString(engagementPopup);
 		ResultActions resultActions = this.testUtils.prepareResultActions(this.mockMvc, request.getMethod(),
-				URL_ENGAGEMENTPOPUP_TEMPLATE, "api/v1/configurations/engagementpopups/post", engagementPopupStr);
+				URL_ENGAGEMENTPOPUP_TEMPLATE, "api/v1/configurations/engagementpopups/post", engagementPopupStr, null);
 
 		MvcResult result = resultActions.andReturn();
 		String objString = result.getResponse().getContentAsString();
@@ -500,7 +500,7 @@ public class ConfigurationControllerTest {
 
 		String engagementPopupStr = objectMapper.writeValueAsString(engagementPopup);
 		ResultActions resultActions = this.testUtils.prepareResultActions(this.mockMvc, request.getMethod(),
-		URL_ENGAGEMENTPOPUP_TEMPLATE, "api/v1/configurations/engagementpopups/put", engagementPopupStr);
+		URL_ENGAGEMENTPOPUP_TEMPLATE, "api/v1/configurations/engagementpopups/put", engagementPopupStr, null);
 
 		MvcResult result = resultActions.andReturn();
 		String objString = result.getResponse().getContentAsString();
@@ -526,7 +526,7 @@ public class ConfigurationControllerTest {
 
 		when(configurationService.deleteEngagementPopup(any(HttpServletRequest.class), any(String.class))).thenReturn(apiResponse);
 		ResultActions resultActions = this.testUtils.prepareResultActions(this.mockMvc, request.getMethod(),
-		URL_ENGAGEMENTPOPUP_TEMPLATE + "/" + engagementPopup.getId(), "api/v1/configurations/engagementpopups/delete", null);
+		URL_ENGAGEMENTPOPUP_TEMPLATE + "/" + engagementPopup.getId(), "api/v1/configurations/engagementpopups/delete", null, null);
 
 		MvcResult result = resultActions.andReturn();
 		String objString = result.getResponse().getContentAsString();

--- a/src/test/java/gov/dot/its/datahub/adminapi/controller/DataAssetsControllerTest.java
+++ b/src/test/java/gov/dot/its/datahub/adminapi/controller/DataAssetsControllerTest.java
@@ -3,9 +3,8 @@ package gov.dot.its.datahub.adminapi.controller;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.when;
-import static java.lang.System.out;
 
 import java.security.SecureRandom;
 import java.sql.Timestamp;
@@ -14,6 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -81,25 +81,21 @@ public class DataAssetsControllerTest {
 		request.setMethod("GET");
 
 		List<DataAsset> dataAssets = this.getFakeDataAssets();
+		dataAssets = dataAssets.stream().filter(d -> !d.getTags().contains(this.maskTag)).collect(Collectors.toList());
 
 		ApiResponse<List<DataAsset>> apiResponse = new ApiResponse<>();
 		apiResponse.setResponse(HttpStatus.OK, dataAssets, null, null, request);
 
-		when(dataAssetsService.dataAssets(any(HttpServletRequest.class), eq(false))).thenReturn(apiResponse);
+		when(dataAssetsService.dataAssets(any(HttpServletRequest.class), anyBoolean())).thenReturn(apiResponse);
 		ResultActions resultActions = this.testUtils.prepareResultActions(this.mockMvc, request.getMethod(),
 				URL_DATAASSETS_TEMPLATE, "api/v1/dataassets/get", "", null);
 
 		MvcResult result = resultActions.andReturn();
 		String objString = result.getResponse().getContentAsString();
 
-		out.println("objString");
-		out.println(objString);
 		TypeReference<ApiResponse<List<DataAsset>>> valueType = new TypeReference<ApiResponse<List<DataAsset>>>() {
 		};
 		ApiResponse<List<DataAsset>> responseApi = objectMapper.readValue(objString, valueType);
-		
-		out.println("SIZE");
-		out.println(responseApi.getResult().size());
 
 		assertEquals(HttpStatus.OK.value(), responseApi.getCode());
 		assertTrue(!responseApi.getResult().isEmpty());
@@ -121,7 +117,7 @@ public class DataAssetsControllerTest {
 		Map<String, String> requestParams = new HashMap<>();
 		requestParams.put("includeMasked", "true");
 
-		when(dataAssetsService.dataAssets(any(HttpServletRequest.class), eq(true))).thenReturn(apiResponse);
+		when(dataAssetsService.dataAssets(any(HttpServletRequest.class), anyBoolean())).thenReturn(apiResponse);
 		ResultActions resultActions = this.testUtils.prepareResultActions(this.mockMvc, request.getMethod(),
 				URL_DATAASSETS_TEMPLATE, "api/v1/dataassets/get", "", requestParams);
 

--- a/src/test/java/gov/dot/its/datahub/adminapi/controller/HealthControllerTest.java
+++ b/src/test/java/gov/dot/its/datahub/adminapi/controller/HealthControllerTest.java
@@ -47,7 +47,7 @@ public class HealthControllerTest {
 		apiResponse.setResponse(HttpStatus.OK, new Date(), null, null, request);
 
 		ResultActions resultActions = this.testUtils.prepareResultActions(this.mockMvc, request.getMethod(),
-				"%s/health", "api/health/data", "");
+				"%s/health", "api/health/data", "", null);
 
 		MvcResult result = resultActions.andReturn();
 		String objString = result.getResponse().getContentAsString();

--- a/src/test/java/gov/dot/its/datahub/adminapi/model/DataAssetTest.java
+++ b/src/test/java/gov/dot/its/datahub/adminapi/model/DataAssetTest.java
@@ -15,23 +15,4 @@ public class DataAssetTest {
 		DataAsset dataAsset = new DataAsset();
 		assertNotNull(dataAsset);
 	}
-	
-	@Test
-	public void testHiddenAsset() {
-		DataAsset dataAsset = new DataAsset();
-		List<String> tags = new ArrayList<>();
-		tags.add("its-datahub-hide");
-		dataAsset.setTags(tags);
-		assertTrue(dataAsset.isHidden());
-    }
-	
-	@Test
-	public void testNonHiddenAsset() {
-		DataAsset dataAsset = new DataAsset();
-		List<String> tags = new ArrayList<>();
-		tags.add("its-datahub-hide");
-		dataAsset.setTags(tags);
-		assertTrue(!dataAsset.isHidden());
-    }
-    
 }

--- a/src/test/java/gov/dot/its/datahub/adminapi/model/DataAssetTest.java
+++ b/src/test/java/gov/dot/its/datahub/adminapi/model/DataAssetTest.java
@@ -1,6 +1,10 @@
 package gov.dot.its.datahub.adminapi.model;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.Test;
 
@@ -10,7 +14,24 @@ public class DataAssetTest {
 	public void testInstance() {
 		DataAsset dataAsset = new DataAsset();
 		assertNotNull(dataAsset);
+	}
+	
+	@Test
+	public void testHiddenAsset() {
+		DataAsset dataAsset = new DataAsset();
+		List<String> tags = new ArrayList<>();
+		tags.add("its-datahub-hide");
+		dataAsset.setTags(tags);
+		assertTrue(dataAsset.isHidden());
     }
-    
+	
+	@Test
+	public void testNonHiddenAsset() {
+		DataAsset dataAsset = new DataAsset();
+		List<String> tags = new ArrayList<>();
+		tags.add("its-datahub-hide");
+		dataAsset.setTags(tags);
+		assertTrue(!dataAsset.isHidden());
+    }
     
 }

--- a/src/test/java/gov/dot/its/datahub/adminapi/testutils/TestUtils.java
+++ b/src/test/java/gov/dot/its/datahub/adminapi/testutils/TestUtils.java
@@ -1,5 +1,8 @@
 package gov.dot.its.datahub.adminapi.testutils;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -28,20 +31,27 @@ public class TestUtils {
 	private Environment env;
 
 	public ResultActions prepareResultActions(MockMvc mockMvc, String requestMethod, String testUrlTemplate,
-			String documentPath, String objStr)  throws Exception { // NOSONAR
-		return this.prepareResultActions(mockMvc, requestMethod, testUrlTemplate, documentPath, objStr, false);
+			String documentPath, String objStr, Map<String,String> requestParams)  throws Exception { // NOSONAR
+		return this.prepareResultActions(mockMvc, requestMethod, testUrlTemplate, documentPath, objStr, requestParams, false);
 	}
 
 	public ResultActions prepareResultActions(MockMvc mockMvc, String requestMethod, String testUrlTemplate,
-			String documentPath, String objStr,boolean noTokenHeader) throws Exception { // NOSONAR
+			String documentPath, String objStr, Map<String,String> requestParams, boolean noTokenHeader) throws Exception { // NOSONAR
 		String tokenKey = env.getProperty(SECURITY_TOKEN_KEY);
 		String tokenName = env.getProperty(SECURITY_TOKEN_NAME);
+
+		Map<String,String> params = requestParams == null ? new HashMap<>() : requestParams;
 
 		MockHttpServletRequestBuilder request = null;
 		switch (requestMethod) {
 		case "GET":
-			request = get(String.format(testUrlTemplate, env.getProperty(SERVER_SERVLET_CONTEXT_PATH)))
-			.contextPath(String.format("%s", env.getProperty(SERVER_SERVLET_CONTEXT_PATH)));
+			request = get(String.format(testUrlTemplate, env.getProperty(SERVER_SERVLET_CONTEXT_PATH)));
+			for (Map.Entry<String, String> param : params.entrySet()) {
+				String key = param.getKey();
+				String value = param.getValue();
+				request = request.param(key, value);
+			}
+			request = request.contextPath(String.format("%s", env.getProperty(SERVER_SERVLET_CONTEXT_PATH)));
 			break;
 		case "POST":
 			request = post(String.format(testUrlTemplate, env.getProperty(SERVER_SERVLET_CONTEXT_PATH)))


### PR DESCRIPTION
[RDAODTD-2327](https://usdotjpoode.atlassian.net/browse/RDAODTD-2327): Update ITS DataHub Admin API to return only assets without a "mask" tag

At times, an ITS JPO dataset may need to be hidden from ITS DataHub but still be discoverable via data.transportation.gov. This PR will allow us to address this use case quickly by adding a tag to the dataset on data.tranportation.gov while allowing us to keep a catalog of all ITS JPO datasets in our Elasticsearch database.

This PR modifies the GET dataaset endpoint to take in an additional parameter: `includeMasked`. 
By default, `includeMasked` will be set to `false` when not given or when given as "false", and will return assets that do not have the "mask" tag. In our case, the "mask" tag is currently set to `its-datahub-hide`.

When `includeMasked` is given as anything other than "false", the endpoint will return all data assets.